### PR TITLE
Add simplified & stylized flat logo for later reference.

### DIFF
--- a/Experimental/logo-simplified.svg
+++ b/Experimental/logo-simplified.svg
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="290"
+   height="201"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="logo-simplified.svg"
+   inkscape:export-filename="/Users/jwecker/src/Nim/web/assets/images/logo-flat.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5041">
+      <stop
+         style="stop-color:#3e4b4b;stop-opacity:1;"
+         offset="0"
+         id="stop5043" />
+      <stop
+         style="stop-color:#1e3449;stop-opacity:1;"
+         offset="1"
+         id="stop5045" />
+    </linearGradient>
+    <filter
+       height="1.9940405"
+       y="-0.49702027"
+       width="1.480671"
+       x="-0.24033555"
+       id="filter5481"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5483"
+         stdDeviation="33.342321"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       height="1.3313468"
+       y="-0.16567342"
+       width="1.1602237"
+       x="-0.080111854"
+       id="filter5475"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5477"
+         stdDeviation="11.114107"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       id="filter5445"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5447"
+         stdDeviation="3.7047023"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       height="1.4332522"
+       y="-0.21662608"
+       width="1.1438614"
+       x="-0.071930707"
+       id="filter5493"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5495"
+         stdDeviation="10.802371"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       id="filter5497"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5499"
+         stdDeviation="3.6007903"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       height="1.4644001"
+       y="-0.2322"
+       width="1.1407273"
+       x="-0.070363633"
+       id="filter9666"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur9668"
+         stdDeviation="4.4075002"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       id="filter9638"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur9640"
+         stdDeviation="1.4691668"
+         inkscape:collect="always" />
+    </filter>
+    <radialGradient
+       r="640"
+       fy="825.16089"
+       fx="293.49887"
+       cy="825.16089"
+       cx="293.49887"
+       gradientTransform="matrix(2.7998301,-1.4738538,0.45507806,0.86449643,-926.2596,769.338)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3133"
+       xlink:href="#linearGradient4453-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4453-1">
+      <stop
+         id="stop4455-4"
+         offset="0"
+         style="stop-color:#070808;stop-opacity:1" />
+      <stop
+         id="stop4457-0"
+         offset="1"
+         style="stop-color:#152534;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4453-1"
+       id="radialGradient5031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.63433651,-0.41145084,0.10310362,0.24133858,422.98257,695.60163)"
+       cx="293.49887"
+       cy="825.16089"
+       fx="293.49887"
+       fy="825.16089"
+       r="640" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5041"
+       id="radialGradient5039"
+       cx="830.83844"
+       cy="627.11255"
+       fx="830.83844"
+       fy="627.11255"
+       r="56.000198"
+       gradientTransform="matrix(1,0,0,0.54464091,0,285.5614)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5041"
+       id="radialGradient5047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.54464091,0,285.5614)"
+       cx="830.83844"
+       cy="627.11255"
+       fx="830.83844"
+       fy="627.11255"
+       r="56.000198" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5041"
+       id="radialGradient5049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.54464091,0,285.5614)"
+       cx="830.83844"
+       cy="627.11255"
+       fx="830.83844"
+       fy="627.11255"
+       r="56.000198" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5041"
+       id="radialGradient5051"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.54464091,0,285.5614)"
+       cx="830.83844"
+       cy="627.11255"
+       fx="830.83844"
+       fy="627.11255"
+       r="56.000198" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5041"
+       id="radialGradient5053"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.54464091,0,285.5614)"
+       cx="830.83844"
+       cy="627.11255"
+       fx="830.83844"
+       fy="627.11255"
+       r="56.000198" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#222430"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.41176471"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="-12.99216"
+     inkscape:cy="-25.885613"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1440"
+     inkscape:window-height="851"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-from-guide="true"
+     guidetolerance="3">
+    <sodipodi:guide
+       orientation="0,1"
+       position="-122.36097,122"
+       id="guide3914" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="141.38903,161.25"
+       id="guide3918" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid3936"
+       empspacing="7"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       color="#ffb400"
+       opacity="0.2"
+       empcolor="#ff6700"
+       empopacity="0.4627451"
+       spacingx="0.5px"
+       spacingy="0.5px"
+       originx="-684.36097px"
+       originy="-30.000001px" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="198.63903,117.25"
+       id="guide4407" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="203.13903,173.5"
+       id="guide4409" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="204.63903,178.5"
+       id="guide4411" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     sodipodi:insensitive="true"
+     style="display:none"
+     transform="translate(-632.83826,-573.61255)">
+    <image
+       y="392.14789"
+       x="-90.714287"
+       id="image3047"
+       xlink:href="file:///home/tomasi/Projects/nimrod/logo/new-symbols.png"
+       height="329"
+       width="800" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline"
+     transform="translate(-632.83826,-573.61255)">
+    <rect
+       style="color:#000000;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect4451"
+       width="290"
+       height="201"
+       x="632.83826"
+       y="573.61255" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 1209.2283,729.23513 -28.65,0 0,7.28362 c 0,1.59787 0.4668,2.98732 1.4003,4.16834 0.9336,1.18104 2.0863,1.84067 3.4542,1.77155 l 23.6088,0 0,5.013 -25.1124,0 c -2.2405,0 -4.1698,-0.86841 -5.7879,-2.60522 -1.556,-1.80627 -2.3339,-3.95992 -2.3339,-6.46093 l 0,-24.59324 c 0,-2.50097 0.7779,-4.61988 2.3339,-6.35673 1.6181,-1.80625 3.5474,-2.70938 5.7879,-2.70942 l 17.1773,0 c 2.2405,4e-5 4.1387,0.90317 5.6946,2.70942 1.6181,1.73685 2.4272,3.85576 2.4272,6.35673 l 0,15.42288 m -4.9576,-4.59617 0,-8.93996 c 0,-1.59784 -0.4668,-2.98729 -1.4003,-4.16836 -0.9336,-1.18099 -2.1161,-1.77151 -3.5475,-1.77154 l -13.8901,0 c -1.3693,3e-5 -2.5206,0.59055 -3.4542,1.77154 -0.9335,1.18107 -1.6566,2.59635 -1.4003,4.16836 l 0,8.93996 23.6924,0 m -40.8208,-41.56827 -0.093,64.40095 -25.4857,0 c -2.2406,0 -4.1699,-0.86841 -5.788,-2.60522 -1.5559,-1.80627 -2.3339,-3.95992 -2.3339,-6.46093 l 0.093,-24.59324 c 0.062,-2.50097 0.8713,-4.61988 2.4272,-6.35673 1.5559,-1.80625 3.4541,-2.70938 5.6947,-2.70942 l 20.3414,0 0.093,-21.67541 5.051,0 m -5.1444,59.80479 -0.093,-33.53321 -18.7445,0 c -1.3692,4e-5 -2.5206,0.66002 -3.4542,1.97996 -0.9335,1.32001 -1.4003,2.77893 -1.4003,4.37677 l 0.093,20.81975 c 0,1.59787 0.4357,3.05679 1.307,4.37675 0.8713,1.31999 1.9915,1.97998 3.3608,1.97998 l 18.9312,0 m -40.4211,-4.46999 c 0,2.50101 -0.8091,4.65466 -2.4272,6.46093 -1.5559,1.73681 -3.4541,2.60522 -5.6946,2.60522 l -19.0443,0 c -2.2406,0 -4.1699,-0.86841 -5.788,-2.60522 -1.5559,-1.80627 -2.3339,-3.95992 -2.3339,-6.46093 l 0,-24.59324 c 0,-2.50097 0.778,-4.61988 2.3339,-6.35673 1.6181,-1.80625 3.5474,-2.70938 5.788,-2.70942 l 19.0443,0 c 2.2405,4e-5 4.1387,0.90317 5.6946,2.70942 1.6181,1.73685 2.4272,3.85576 2.4272,6.35673 l 0,24.59324 m -4.9576,-1.88674 0,-20.81975 c 0,-1.59784 -0.4668,-2.98729 -1.4003,-4.16836 -0.9336,-1.18099 -2.1161,-1.77151 -3.5475,-1.77154 l -15.7572,0 c -1.3692,3e-5 -2.5206,0.59055 -3.4541,1.77154 -0.9336,1.18107 -1.4004,2.57052 -1.4004,4.16836 l 0,20.81975 c 0,1.59787 0.4668,2.98732 1.4004,4.16834 0.9335,1.18104 2.0849,1.77155 3.4541,1.77155 l 15.7572,0 c 1.4314,0 2.6139,-0.59051 3.5475,-1.77155 0.9335,-1.18102 1.4003,-2.57047 1.4003,-4.16834 m -43.2742,-8.62734 -4.9577,0 0,-12.19241 c 0,-1.59784 -0.4667,-2.98729 -1.4003,-4.16836 -0.9335,-1.18099 -2.116,-1.77151 -3.5474,-1.77154 l -13.8902,0 c -1.3692,3e-5 -2.5206,0.59055 -3.4541,1.77154 -0.9336,1.18107 -1.4003,2.57052 -1.4003,4.16836 l 0,20.81975 c 0,1.59787 0.4667,2.98732 1.4003,4.16834 0.9335,1.18104 2.0849,1.77155 3.4541,1.77155 l 23.5155,0 0.093,5.013 -25.1124,0 c -2.2405,0 -4.1698,-0.86841 -5.7879,-2.60522 -1.5559,-1.80627 -2.3339,-3.95992 -2.3339,-6.46093 l 0,-24.59324 c 0,-2.50097 0.778,-4.61988 2.3339,-6.35673 1.6181,-1.80625 3.5474,-2.70938 5.7879,-2.70942 l 17.1773,0 c 2.2405,4e-5 4.1387,0.90317 5.6946,2.70942 1.6181,1.73685 2.4272,3.85576 2.4272,6.35673 l 0,14.07916"
+       style="font-size:87.35703278px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:none;font-family:Discognate;-inkscape-font-specification:Discognate"
+       id="path4870" />
+    <g
+       id="g4469"
+       transform="translate(0,-2)">
+      <g
+         id="g4463">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 774.83823,652.61255 0,-39 c 0,0 14.0008,0 19.5004,0 5.4996,0 10.4996,5 10.5,10.5 4e-4,5.5 0,28.5 0,28.5 l -7,0 c 0,0 -3.9e-4,-18 -4e-4,-27 0,-2.71875 -2,-5 -5,-5 -3.66681,0 -11,0 -11,0 l 0,37 z"
+           id="path3118"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cczzccssccc" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 817.83863,652.61255 0,-39 7,0 0,39 z"
+           id="path3120"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 817.83863,604.61255 7,0 0,-8 -7,5 z"
+           id="path3122"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 844.83863,652.61255 -7,0 0,-39 38.5,0 c 6,0 10.49999,4.5 10.5,10.5 l 0,28.5 -7,5 -4e-4,-32 c -4e-5,-3 -2,-5 -5,-5 l -8.9996,0 0,32 -7,0 0,-32 -14,0 z"
+           id="path3124"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccssccsscccccc" />
+      </g>
+      <g
+         id="g4459">
+        <path
+           style="fill:#f3d400;fill-opacity:1;stroke:none"
+           d="m 709.69141,596.61258 c 0,0 -3.41031,2.69499 -6.88691,5.37174 -3.57641,-0.11362 -10.59106,0.68718 -14.39187,2.06946 -3.50133,-2.21819 -6.57787,-4.66728 -6.57787,-4.66728 0,0 -2.62896,4.52282 -4.28224,7.17702 -2.45187,1.30403 -4.91362,2.77074 -7.10764,4.7113 -2.55188,-1.01333 -5.5101,-2.24876 -5.60665,-2.28959 3.37945,6.81645 5.65131,13.64192 11.83134,17.74436 9.83897,-15.53906 55.55981,-14.10685 65.60219,-0.0881 6.49004,-3.38511 9.01412,-10.66815 11.56647,-17.39212 -0.27986,0.0922 -3.75271,1.25487 -6.00396,2.11349 -1.34414,-1.46336 -4.51234,-3.71327 -6.31301,-4.79936 -1.70802,-3.12771 -4.19395,-7.35313 -4.19395,-7.35313 0,0 -2.94437,2.1899 -6.35714,4.5792 -4.61059,-0.85108 -10.1872,-1.88519 -14.87749,-1.62916 -3.19286,-2.62436 -6.40127,-5.54786 -6.40127,-5.54786 z"
+           id="path3054"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccc" />
+        <path
+           style="fill:#ffe953;fill-opacity:1;stroke:none"
+           d="m 668.33241,623.47127 c 0,0 4.78987,11.5978 8.1165,19.65678 14.09625,18.59727 50.09234,19.89014 65.7848,0.36006 3.71345,-8.36876 8.72334,-20.1298 8.72334,-20.1298 -4.0259,5.96409 -10.5778,10.08114 -14.61301,12.29885 -2.86735,1.57082 -9.48338,2.52031 -9.48338,2.52031 l -17.36961,-9.00108 -17.46941,8.82104 c 0,0 -6.52806,-1.04882 -9.4834,-2.4303 -5.96472,-3.18408 -9.9764,-6.94592 -14.20583,-12.09586 z"
+           id="path3051"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+      </g>
+    </g>
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       id="rect4443"
+       width="250"
+       height="75"
+       x="654.83826"
+       y="676.61255" />
+    <g
+       id="g4481"
+       transform="translate(-1.6357423e-6,89.000001)"
+       style="fill:url(#radialGradient5039);fill-opacity:1">
+      <path
+         style="fill:url(#radialGradient5047);fill-opacity:1;stroke:none"
+         d="m 774.83823,652.61255 0,-39 c 0,0 14.0008,0 19.5004,0 5.4996,0 10.4996,5 10.5,10.5 4e-4,5.5 0,28.5 0,28.5 l -7,0 c 0,0 -3.9e-4,-18 -4e-4,-27 0,-2.71875 -2,-5 -5,-5 -3.66681,0 -11,0 -11,0 l 0,37 z"
+         id="path4483"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cczzccssccc" />
+      <path
+         style="fill:url(#radialGradient5049);fill-opacity:1;stroke:none"
+         d="m 817.83863,652.61255 0,-39 7,0 0,39 z"
+         id="path4485"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#radialGradient5051);fill-opacity:1;stroke:none"
+         d="m 817.83863,604.61255 7,0 0,-8 -7,5 z"
+         id="path4487"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#radialGradient5053);fill-opacity:1;stroke:none"
+         d="m 844.83863,652.61255 -7,0 0,-39 38.5,0 c 6,0 10.49999,4.5 10.5,10.5 l 0,28.5 -7,5 -4e-4,-32 c -4e-5,-3 -2,-5 -5,-5 l -8.9996,0 0,32 -7,0 0,-32 -14,0 z"
+         id="path4489"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccssccsscccccc" />
+    </g>
+    <g
+       id="g4491"
+       transform="translate(-1.6357423e-6,89.000001)">
+      <path
+         style="fill:#dfad00;fill-opacity:1;stroke:none"
+         d="m 709.69141,596.61258 c 0,0 -3.41031,2.69499 -6.88691,5.37174 -3.57641,-0.11362 -10.59106,0.68718 -14.39187,2.06946 -3.50133,-2.21819 -6.57787,-4.66728 -6.57787,-4.66728 0,0 -2.62896,4.52282 -4.28224,7.17702 -2.45187,1.30403 -4.91362,2.77074 -7.10764,4.7113 -2.55188,-1.01333 -5.5101,-2.24876 -5.60665,-2.28959 3.37945,6.81645 5.65131,13.64192 11.83134,17.74436 9.83897,-15.53906 55.55981,-14.10685 65.60219,-0.0881 6.49004,-3.38511 9.01412,-10.66815 11.56647,-17.39212 -0.27986,0.0922 -3.75271,1.25487 -6.00396,2.11349 -1.34414,-1.46336 -4.51234,-3.71327 -6.31301,-4.79936 -1.70802,-3.12771 -4.19395,-7.35313 -4.19395,-7.35313 0,0 -2.94437,2.1899 -6.35714,4.5792 -4.61059,-0.85108 -10.1872,-1.88519 -14.87749,-1.62916 -3.19286,-2.62436 -6.40127,-5.54786 -6.40127,-5.54786 z"
+         id="path4493"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccc" />
+      <path
+         style="fill:#f6d600;fill-opacity:1;stroke:none"
+         d="m 668.33241,623.47127 c 0,0 4.78987,11.5978 8.1165,19.65678 14.09625,18.59727 50.09234,19.89014 65.7848,0.36006 3.71345,-8.36876 8.72334,-20.1298 8.72334,-20.1298 -4.0259,5.96409 -10.5778,10.08114 -14.61301,12.29885 -2.86735,1.57082 -9.48338,2.52031 -9.48338,2.52031 l -17.36961,-9.00108 -17.46941,8.82104 c 0,0 -6.52806,-1.04882 -9.4834,-2.4303 -5.96472,-3.18408 -9.9764,-6.94592 -14.20583,-12.09586 z"
+         id="path4495"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
As per request from https://github.com/Araq/Nim/pull/2745

- Proportions and spacing polished
- Aspect ratio flattened slightly
- Crown is two simple paths with negative space between
- Crown has some of the lower points subtly removed so it's more effective in smaller sizes
- No filters or blur
- No outlines
- Most gradients gone, remaining more subtle
- Some experiments w/ color